### PR TITLE
Issue #6: Refactor Wet Code logic for syncing functions 

### DIFF
--- a/tap_freshsales/__init__.py
+++ b/tap_freshsales/__init__.py
@@ -201,11 +201,9 @@ def get_filters(endpoint):
         'tasks': ['open', 'due today', 'due tomorrow', 'overdue', 'completed'],
         'appointments': ['past', 'upcoming']
     }
-
     if endpoint not in edge_case_filters.keys():
         url = get_url(endpoint, query='filters')
         filters = list(gen_request(url))[0]['filters']
-
     else:
         filters = edge_case_filters[endpoint]
     return filters
@@ -239,7 +237,7 @@ def sync_current_endpoint_data_stream(endpoint):
 
 def get_endpoint_resource(endpoint, fil):
     """
-
+    Generate endpoint resource based on the endpoint given.
     :param endpoint: current endpoint
     :param fil: current filter
     :return:

--- a/tap_freshsales/__init__.py
+++ b/tap_freshsales/__init__.py
@@ -195,8 +195,19 @@ def get_filters(endpoint):
     Use Freshsales API structure to derive filters for an
     endpoint in the supported streams
     """
-    url = get_url(endpoint, query='filters')
-    filters = list(gen_request(url))[0]['filters']
+    # Moved filter edge-cases for `tasks` and `appointments` to this function
+    # TODO: Find out why there is a special use-case for `tasks` filter and remove hard-coded filter if possible
+    edge_case_filters = {
+        'tasks': ['open', 'due today', 'due tomorrow', 'overdue', 'completed'],
+        'appointments': ['past', 'upcoming']
+    }
+
+    if endpoint not in edge_case_filters.keys():
+        url = get_url(endpoint, query='filters')
+        filters = list(gen_request(url))[0]['filters']
+
+    else:
+        filters = edge_case_filters[endpoint]
     return filters
 
 
@@ -210,251 +221,70 @@ def get_start(entity):
         STATE[entity] = CONFIG['start_date']
     return STATE[entity]
 
-# TODO: This is very WET code , clean it up with streams mechanism
-# Sync accounts
 
-
-def sync_accounts():
+def sync_current_endpoint_data_stream(endpoint):
     """
-    Sync Sales Accounts Data, Standard schema is kept as columns,
+    Sync current data resource. Standard schema is kept as columns,
     Custom fields are saved as JSON content
+    :return:
     """
     bookmark_property = 'updated_at'
-    endpoint = 'accounts'
     schema = tap_utils.load_schema(endpoint)
-    singer.write_schema(endpoint,
-                        schema,
-                        ["id"],
-                        bookmark_properties=[bookmark_property])
+    singer.write_schema(endpoint, schema, ["id"], bookmark_properties=[bookmark_property])
     filters = get_filters(endpoint)
+
     for fil in filters:
-        sync_accounts_by_filter(bookmark_property, fil)
-
-# Batch sync accounts while bookmarking updated at
+        sync_current_endpoint_by_filter(bookmark_property, fil)
 
 
-def sync_accounts_by_filter(bookmark_prop, fil):
+def get_endpoint_resource(endpoint, fil):
     """
-    Sync accounts by view based filters, use bookmark property
+
+    :param endpoint: current endpoint
+    :param fil: current filter
+    :return:
+    """
+    fil_id = fil['id']
+
+    if endpoint in ['accounts', 'contacts', 'deals', 'leads']:
+        endpoint_resources = gen_request(get_url(endpoint, query='view/' + str(fil_id)))
+    elif endpoint == 'appointments':
+        endpoint_resources = gen_request(get_url(endpoint, filter=fil, include='creater,targetable,appointment_attendees'))
+    elif endpoint == 'tasks':
+        endpoint_resources = gen_request(get_url(endpoint, filter=fil, include='owner,users,targetable'))
+    else:
+        endpoint_resources = gen_request(get_url(endpoint))
+
+    return endpoint_resources
+
+
+def sync_current_endpoint_by_filter(endpoint, bookmark_property, fil):
+    """
+    Sync current endpoint while bookmarking updated at by view based filters, use bookmark property
     to manage state and fetch data updated since particular time
+
+    # Batch sync accounts
     """
-    endpoint = 'accounts'
     fil_id = fil['id']
     state_entity = endpoint + "_" + str(fil_id)
+    # TODO: Verify updated_at exists for `appointments` endpoint
     start = get_start(state_entity)
-    accounts = gen_request(get_url(endpoint, query='view/'+str(fil_id)))
-    for acc in accounts:
-        if acc[bookmark_prop] >= start:
-            LOGGER.info("Account {}: Syncing details".format(acc['id']))
-            acc['custom_field'] = json.dumps(acc['custom_field'])
-            singer.write_record(
-                "accounts", acc, time_extracted=singer.utils.now())
 
+    endpoint_resources = get_endpoint_resource(endpoint, fil)
+    for endpoint_resource in endpoint_resources:
+        LOGGER.info("{} {}: Syncing details".format(endpoint, endpoint_resource['id']))
 
-def sync_contacts():
-    """
-    Sync Sales Accounts Data, Standard schema is kept as columns,
-    Custom fields are saved as JSON content
-    """
-    bookmark_property = 'updated_at'
-    endpoint = 'contacts'
-    schema = tap_utils.load_schema(endpoint)
-    singer.write_schema(endpoint,
-                        schema,
-                        ["id"],
-                        bookmark_properties=[bookmark_property])
-    filters = get_filters(endpoint)
-    for fil in filters:
-        sync_contacts_by_filter(bookmark_property, fil)
+        if endpoint_resource[bookmark_property] >= start:
+            # Specific edge-case handling for deals endpoint
+            if endpoint == 'deals' and endpoint_resource[bookmark_property]:
+                endpoint_resource['amount'] = float(endpoint_resource['amount'])
 
-# Batch sync contacts while bookmarking updated at
-
-
-def sync_contacts_by_filter(bookmark_prop, fil):
-    """
-    Sync all contacts updated after bookmark time
-    """
-    endpoint = 'contacts'
-    fil_id = fil['id']
-    state_entity = endpoint + "_" + str(fil_id)
-    start = get_start(state_entity)
-    contacts = gen_request(get_url(endpoint, query='view/'+str(fil_id)))
-    for con in contacts:
-        if con[bookmark_prop] >= start:
-            LOGGER.info("Contact {}: Syncing details".format(con['id']))
-            tap_utils.update_state(STATE, state_entity, con[bookmark_prop])
-            singer.write_record(
-                endpoint, con, time_extracted=singer.utils.now())
+            tap_utils.update_state(STATE, state_entity, endpoint_resource[bookmark_property])
+            endpoint_resource['custom_field'] = json.dumps(endpoint_resource['custom_field'])
+            singer.write_record(endpoint, endpoint_resource, time_extracted=singer.utils.now())
             singer.write_state(STATE)
 
-# Batch sync deals and stages of deals
-
-
-def sync_deals():
-    """
-    Sync deals for every view
-    """
-    bookmark_property = 'updated_at'
-    endpoint = 'deals'
-    singer.write_schema(endpoint,
-                        tap_utils.load_schema(endpoint),
-                        ["id"],
-                        bookmark_properties=[bookmark_property])
-    filters = get_filters(endpoint)
-    for fil in filters:
-        sync_deals_by_filter(bookmark_property, fil)
-
-# Batch sync deals with bookmarking on update time
-
-
-def sync_deals_by_filter(bookmark_prop, fil):
-    """
-    Iterate over all deal filter to sync all deal data
-    """
-    endpoint = 'deals'
-    fil_id = fil['id']
-    state_entity = endpoint + "_" + str(fil_id)
-    start = get_start(state_entity)
-    deals = gen_request(get_url(endpoint, query='view/'+str(fil_id)))
-    for deal in deals:
-        if deal[bookmark_prop] >= start:
-            # get all sub-entities and save them
-            deal['amount'] = float(deal['amount'])  # cast amount to float
-            deal['custom_field'] = json.dumps(
-                deal['custom_field'])  # Make JSON String to store
-            LOGGER.info("Deal {}: Syncing details".format(deal['id']))
-            singer.write_record(
-                "deals", deal, time_extracted=singer.utils.now())
-
-# Sync leads across all filters
-
-
-def sync_leads():
-    """
-    Sync leads data and call out to per-filter sync
-    """
-    bookmark_property = 'updated_at'
-    endpoint = 'leads'
-    singer.write_schema(endpoint,
-                        tap_utils.load_schema(endpoint),
-                        ["id"],
-                        bookmark_properties=[bookmark_property])
-    filters = get_filters(endpoint)
-    for fil in filters:
-        sync_leads_by_filter(bookmark_property, fil)
-
-# Fetch leads for a particular filter for sync
-
-
-def sync_leads_by_filter(bookmark_prop, fil):
-    """
-    Iterate over all leads in a filter and consume generator
-    to yield schema rows
-    """
-    endpoint = 'leads'
-    fil_id = fil['id']
-    state_entity = endpoint + "_" + str(fil_id)
-    start = get_start(state_entity)
-    leads = gen_request(get_url(endpoint, query='view/'+str(fil_id)))
-    for lead in leads:
-        if lead[bookmark_prop] >= start:
-            LOGGER.info("Lead {}: Syncing details".format(lead['id']))
-            singer.write_record(
-                "leads", lead, time_extracted=singer.utils.now())
-
-# Fetch tasks stream
-
-
-def sync_tasks():
-    """
-    Sync all task based on filters
-    """
-    endpoint = 'tasks'
-    bookmark_property = 'updated_at'
-    singer.write_schema(endpoint,
-                        tap_utils.load_schema(endpoint),
-                        ["id"],
-                        bookmark_properties=[bookmark_property])
-    # Hardcoded task filters
-    filters = ['open', 'due today', 'due tomorrow', 'overdue', 'completed']
-    for fil in filters:
-        sync_tasks_by_filter(bookmark_property, fil)
-
-# Fetch tasks by all applicable filters
-
-
-def sync_tasks_by_filter(bookmark_prop, fil):
-    """
-    Sync tasks for a specific filter
-    """
-    endpoint = 'tasks'
-    state_entity = endpoint + "_" + str(fil)
-    # TODO: Verify updated-at exists for tasks
-    #start = get_start(state_entity)
-    tasks = gen_request(get_url(endpoint, filter=fil,
-                                include='owner,users,targetable'))
-    for task in tasks:
-        LOGGER.info("Task {}: Syncing details".format(task['id']))
-        singer.write_record(endpoint, task, time_extracted=singer.utils.now())
-
-
-# Fetch sales_activities stream
-def sync_sales_activities():
-    """Sync all sales activities, call out to individual filters
-    """
-
-    bookmark_property = 'updated_at'
-    endpoint = 'sales_activities'
-    state_entity = endpoint
-    start = get_start(state_entity)
-    singer.write_schema(endpoint,
-                        tap_utils.load_schema(endpoint),
-                        ["id"],
-                        bookmark_properties=[bookmark_property])
-    sales = gen_request(get_url(endpoint))
-    for sale in sales:
-        if sale[bookmark_property] >= start:
-            LOGGER.info("Sale {}: Syncing details".format(sale['id']))
-            singer.write_record("sale_activities", sale,
-                                time_extracted=singer.utils.now())
-
-# Fetch all team appointments
-
-
-def sync_appointments():
-    """Sync all appointments
-    """
-
-    endpoint = 'appointments'
-    bookmark_property = 'updated_at'
-    filters = ['past', 'upcoming']
-    singer.write_schema(endpoint,
-                        tap_utils.load_schema(endpoint),
-                        ["id"],
-                        bookmark_properties=[bookmark_property])
-    for fil in filters:
-        sync_appointments_by_filter(bookmark_property, fil)
-
-# Fetch team appointments by filter
-
-
-def sync_appointments_by_filter(bookmark_property, fil):
-    """Iterate over all appointment filter to sync
-
-    Arguments:
-        bookmark_property {[str]} -- [Field used to bookmark stream]
-        fil {[str]} -- [Filter string which yields a subset of the stream]
-    """
-
-    endpoint = 'appointments'
-    # TODO: Verify updated_at exists for appointments
-    #start = get_start(endpoint)
-    appts = gen_request(get_url(endpoint, filter=fil,
-                                include='creater,targetable,appointment_attendees'))
-    for appoint in appts:
-        LOGGER.info("Appointment {}: Syncing details".format(appoint['id']))
-        singer.write_record(endpoint, appoint,
-                            time_extracted=singer.utils.now())
+        singer.write_record(endpoint, endpoint_resource, time_extracted=singer.utils.now())
 
 
 def sync(config, state, catalog):
@@ -468,26 +298,10 @@ def sync(config, state, catalog):
 
     LOGGER.info("Starting FreshSales sync")
     STATE.update(state)
-    # Synchronize x7 data-streams
-    # TODO: Use selected streams only
-    # TODO: Use map based function compresenion to link fetch
-    # function and stream name
     selected_streams = get_selected_streams(catalog)
     try:
-        if 'contacts' in selected_streams:
-            sync_contacts()
-        if 'appointments' in selected_streams:
-            sync_appointments()
-        if 'deals' in selected_streams:
-            sync_deals()
-        if 'sales_activities' in selected_streams:
-            sync_sales_activities()
-        if 'leads' in selected_streams:
-            sync_leads()
-        if 'accounts' in selected_streams:
-            sync_accounts()
-        if 'tasks' in selected_streams:
-            sync_tasks()
+        [sync_current_endpoint_data_stream(stream_endpoint) for stream_endpoint in selected_streams]
+
     except HTTPError as e:
         LOGGER.critical(
             "Error making request to FreshSales API: GET %s: [%s - %s]",

--- a/tap_freshsales/tests/conftest.py
+++ b/tap_freshsales/tests/conftest.py
@@ -21,7 +21,3 @@ def default_session_fixture():
     pytest.TEST_DIR = TEST_DIR
     pytest.TEST_DOMAIN = TEST_DOMAIN
     # Globally activated responses from sample test data
-
-    
-
-    

--- a/tap_freshsales/tests/conftest.py
+++ b/tap_freshsales/tests/conftest.py
@@ -1,4 +1,5 @@
-
+import datetime
+import json
 import pytest
 import tap_freshsales
 import responses
@@ -12,9 +13,6 @@ TEST_DIR = os.path.dirname(__file__)
 def default_session_fixture():
     """Monkey patch globals in freshsales tap module
     """
-
-    import datetime
-    import json
     tap_freshsales.CONFIG = {}
     tap_freshsales.CONFIG['start_date'] = str(datetime.datetime.now())
     tap_freshsales.CONFIG['domain'] = TEST_DOMAIN


### PR DESCRIPTION
PR Objective:  Attempt to address #12 

1. The first objective is this pr removes the redundancies in core logic found within the following functions `sync_accounts`, `sync_contacts`, `sync_leads`, `sync_tasks`, `sync_appointments` and `sync_sales_activities` and replaces those functions, with one function  `sync_current_endpoint_data_stream` that takes in the current endpoint being processed as an argument.
```
def sync_current_endpoint_data_stream(endpoint):
    """
    Sync current data resource. Standard schema is kept as columns,
    Custom fields are saved as JSON content
    :return:
    """
    bookmark_property = 'updated_at'
    schema = tap_utils.load_schema(endpoint)
    singer.write_schema(endpoint, schema, ["id"], bookmark_properties=[bookmark_property])
    filters = get_filters(endpoint)

    for fil in filters:
        sync_current_endpoint_by_filter(bookmark_property, fil)
```

2. Alters the function `get_filters` to handle filter edge_cases for endpoints ['tasks', 'appointments'] and maintains simplicity of the above function. 
```
def get_filters(endpoint):
    """
    Use Freshsales API structure to derive filters for an
    endpoint in the supported streams
    """
    # Moved filter edge-cases for `tasks` and `appointments` to this function
    # TODO: Find out why there is a special use-case for `tasks` filter and remove hard-coded filter if possible
    edge_case_filters = {
        'tasks': ['open', 'due today', 'due tomorrow', 'overdue', 'completed'],
        'appointments': ['past', 'upcoming']
    }
    if endpoint not in edge_case_filters.keys():
        url = get_url(endpoint, query='filters')
        filters = list(gen_request(url))[0]['filters']
    else:
        filters = edge_case_filters[endpoint]
    return filters
```
3. Remove redundancies found in the sync_by_{endpoint}_filter function and replace those with one function `sync_current_endpoint_by_filter`. To maintain code simplicity introduced a new function `get_endpoint_resource` to handle all the scenarios for generating the end point data

```
def get_endpoint_resource(endpoint, fil):
    """
    Generate endpoint resource based on the endpoint given.
    :param endpoint: current endpoint
    :param fil: current filter
    :return:
    """
    fil_id = fil['id']

    if endpoint in ['accounts', 'contacts', 'deals', 'leads']:
        endpoint_resources = gen_request(get_url(endpoint, query='view/' + str(fil_id)))
    elif endpoint == 'appointments':
        endpoint_resources = gen_request(get_url(endpoint, filter=fil, include='creater,targetable,appointment_attendees'))
    elif endpoint == 'tasks':
        endpoint_resources = gen_request(get_url(endpoint, filter=fil, include='owner,users,targetable'))
    else:
        endpoint_resources = gen_request(get_url(endpoint))

    return endpoint_resources
```
