### PR TITLE
zipate: Include owner in Deal/Lead/Account/Contact in ETL

### DIFF
--- a/tap_freshsales/schemas/accounts.json
+++ b/tap_freshsales/schemas/accounts.json
@@ -131,6 +131,48 @@
         },
         "custom_field": {
             "type": ["null","string"]            
+        },
+        "users[id]": {
+          "type": [
+              "null",
+              "number"
+          ]
+        },
+        "users[display_name]": {
+          "type": [
+              "null",
+              "string"
+          ]
+        },
+        "users[avatar]": {
+          "type": [
+              "null",
+              "string"
+          ]
+        },
+        "users[is_active]": {
+          "type": [
+              "null",
+              "boolean"
+          ]
+        },
+        "users[work_number]": {
+          "type": [
+              "null",
+              "string"
+          ]
+        },
+        "users[mobile_number]": {
+          "type": [
+              "null",
+              "string"
+          ]
+        },
+        "users[email]": {
+          "type": [
+              "null",
+              "integer"
+          ]
         }
     }
 }

--- a/tap_freshsales/schemas/contacts.json
+++ b/tap_freshsales/schemas/contacts.json
@@ -176,6 +176,48 @@
                 "null",
                 "integer"
             ]
+        },
+        "users[id]": {
+          "type": [
+              "null",
+              "number"
+          ]
+        },
+        "users[display_name]": {
+          "type": [
+              "null",
+              "string"
+          ]
+        },
+        "users[avatar]": {
+          "type": [
+              "null",
+              "string"
+          ]
+        },
+        "users[is_active]": {
+          "type": [
+              "null",
+              "boolean"
+          ]
+        },
+        "users[work_number]": {
+          "type": [
+              "null",
+              "string"
+          ]
+        },
+        "users[mobile_number]": {
+          "type": [
+              "null",
+              "string"
+          ]
+        },
+        "users[email]": {
+          "type": [
+              "null",
+              "integer"
+          ]
         }
     }
 }

--- a/tap_freshsales/schemas/deals.json
+++ b/tap_freshsales/schemas/deals.json
@@ -119,6 +119,48 @@
         },
         "custom_field": {
             "type": ["null","string"]            
+        },
+        "users[id]": {
+          "type": [
+              "null",
+              "number"
+          ]
+        },
+        "users[display_name]": {
+          "type": [
+              "null",
+              "string"
+          ]
+        },
+        "users[avatar]": {
+          "type": [
+              "null",
+              "string"
+          ]
+        },
+        "users[is_active]": {
+          "type": [
+              "null",
+              "boolean"
+          ]
+        },
+        "users[work_number]": {
+          "type": [
+              "null",
+              "string"
+          ]
+        },
+        "users[mobile_number]": {
+          "type": [
+              "null",
+              "string"
+          ]
+        },
+        "users[email]": {
+          "type": [
+              "null",
+              "integer"
+          ]
         }
     }
 }

--- a/tap_freshsales/schemas/leads.json
+++ b/tap_freshsales/schemas/leads.json
@@ -272,6 +272,48 @@
               "string"
           ],
           "format": "date-time"
+      },
+      "users[id]": {
+          "type": [
+              "null",
+              "number"
+          ]
+      },
+      "users[display_name]": {
+          "type": [
+              "null",
+              "string"
+          ]
+      },
+      "users[avatar]": {
+          "type": [
+              "null",
+              "string"
+          ]
+      },
+      "users[is_active]": {
+          "type": [
+              "null",
+              "boolean"
+          ]
+      },
+      "users[work_number]": {
+          "type": [
+              "null",
+              "string"
+          ]
+      },
+      "users[mobile_number]": {
+          "type": [
+              "null",
+              "string"
+          ]
+      },
+      "users[email]": {
+          "type": [
+              "null",
+              "integer"
+          ]
       }
   }
 }


### PR DESCRIPTION
Changes made to extract correct key from API data as opposed to always picking the first key. The users object was added to the schema and records.